### PR TITLE
Skip input

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,11 @@ on:
         description: A stringified JSON array of the dist-tags to apply.
         required: false
         default: '["latest"]'
+      skip:
+        type: boolean
+        description: Whether to skip the workflow or not.
+        required: false
+        default: false
       skip-ci:
         type: boolean
         description: |
@@ -52,6 +57,7 @@ permissions:
 
 jobs:
   npm-publish:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     outputs:
       package-name: ${{ steps.npm-publish.outputs.package-name }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ could have undesired consequences.
 |:---------:|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  version  |   true   | The release type or the new release version. Either a semantic version or one of "major", "minor", "patch", "premajor", "preminor", "prepatch", or "prerelease".                                    |
 | dist-tags |  false   | A stringified JSON array of the dist-tags to apply. Defaults to '["latest"]'                                                                                                                        |
+|   skip    |  false   | A boolean indicating whether to skip whether to skip the workflow. This is to workaround the required checks path issue when workflows are skipped. It defaults to false.                           |
 |  skip-ci  |  false   | A boolean indicating whether to skip the CI when pushing the git commit or not. This is especially useful if using this workflow on a push event with a GitHub PAT, for example. Defaults to false. |
 
 ## Secrets


### PR DESCRIPTION
- To workaround the known issue where GitHub required checks path isn't the
same when an inner workflow is skipped vs not skipped.
